### PR TITLE
fix(user-data): limit amount of user data retrieved by autocomplete

### DIFF
--- a/src/components/SelectUser/index.js
+++ b/src/components/SelectUser/index.js
@@ -3,6 +3,9 @@ import React, { useState, useEffect } from 'react';
 import Input from '@material-ui/core/Input';
 import MenuItem from '@material-ui/core/MenuItem';
 
+const USER_FETCH_LIMIT = 15;
+const USER_FETCH_FIELDS = 'username';
+
 export default () => {
   const [search, setSearch] = useState('');
   const [userList, setUserList] = useState([]);
@@ -10,9 +13,13 @@ export default () => {
 
   useEffect(() => {
     if (search.length > 2) {
-      User.fetchList({ username: { $regex: search } })
+      User.fetchList({
+        username: { $regex: search },
+        limit: USER_FETCH_LIMIT,
+        fields: USER_FETCH_FIELDS
+      })
         .then(userList => {
-          setUserList(userList.map(user => user.attrs.username).slice(0, 10));
+          setUserList(userList.map(user => user.attrs.username));
         });
     } else {
       setUserList([]);


### PR DESCRIPTION
Use Mongo query parameters to limit the number of users and how much data for each is returned for the autocomplete component